### PR TITLE
Rename New func to avoid alliteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tempdb stores an expiring (or non-expiring) key/value pair in Redis.
 ```go
 import "github.com/rafaeljesus/tempdb"
 
-temp, err := tempdb.NewTempdb(tempdb.Options{
+temp, err := tempdb.New(tempdb.Options{
   Addr: "localhost:6379",
   Password: "foo",
 })

--- a/tempdb.go
+++ b/tempdb.go
@@ -46,10 +46,10 @@ type temp struct {
 	*redis.Client
 }
 
-// NewTempdb returns a new temp configured with the
+// New returns a new temp configured with the
 // variables from the options parameter, or returning an non-nil err
 // if an error ocurred while creating redis client.
-func NewTempdb(o Options) (tempdb Tempdb, err error) {
+func New(o Options) (tempdb Tempdb, err error) {
 	options := newOptions(o)
 	client := redis.NewClient(options)
 	tempdb = &temp{client}

--- a/tempdb_test.go
+++ b/tempdb_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestInsert(t *testing.T) {
-	temp, err := NewTempdb(Options{})
+	temp, err := New(Options{})
 	if err != nil {
 		t.Errorf("Expected to initialize tempdb %s", err)
 	}
@@ -16,7 +16,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	temp, err := NewTempdb(Options{})
+	temp, err := New(Options{})
 	if err != nil {
 		t.Errorf("Expected to initialize tempdb %s", err)
 	}


### PR DESCRIPTION
Changes constructor to just `New`.

The example on the README called my attention since it repeated the name of the package on `tempdb.NewTempdb`.

This is kind of a stylistic change, not a real issue, so feel free to close this if you don't agree.